### PR TITLE
Enable pgsql modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -xe && \
     rm -rf /var/cache/apk/* && \
     php-ext.sh enable 'bcmath curl exif gd imagick intl fileinfo pcntl' && \
     php-ext.sh enable 'pdo mysqlnd pdo_mysql' && \
+    php-ext.sh enable 'pgsql pdo_pgsql' && \
     php-ext.sh enable 'opcache apcu ldap session' && \
     setup-nginx.sh symfony4 /home/project/pixelfed/public && \
     sed -i 's|listen 80;|listen 8000;|' /etc/nginx/conf.d/default.conf && \

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -40,6 +40,7 @@ RUN set -xe && \
     rm -rf /var/cache/apk/* && \
     php-ext.sh enable 'bcmath curl exif gd imagick intl fileinfo pcntl' && \
     php-ext.sh enable 'pdo mysqlnd pdo_mysql' && \
+    php-ext.sh enable 'pgsql pdo_pgsql' && \
     php-ext.sh enable 'opcache apcu ldap session' && \
     setup-nginx.sh symfony4 /home/project/pixelfed/public && \
     sed -i 's|listen 80;|listen 8000;|' /etc/nginx/conf.d/default.conf && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -40,6 +40,7 @@ RUN set -xe && \
     rm -rf /var/cache/apk/* && \
     php-ext.sh enable 'bcmath curl exif gd imagick intl fileinfo pcntl' && \
     php-ext.sh enable 'pdo mysqlnd pdo_mysql' && \
+    php-ext.sh enable 'pgsql pdo_pgsql' && \
     php-ext.sh enable 'opcache apcu ldap session' && \
     setup-nginx.sh symfony4 /home/project/pixelfed/public && \
     sed -i 's|listen 80;|listen 8000;|' /etc/nginx/conf.d/default.conf && \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -40,6 +40,7 @@ RUN set -xe && \
     rm -rf /var/cache/apk/* && \
     php-ext.sh enable 'bcmath curl exif gd imagick intl fileinfo pcntl' && \
     php-ext.sh enable 'pdo mysqlnd pdo_mysql' && \
+    php-ext.sh enable 'pgsql pdo_pgsql' && \
     php-ext.sh enable 'opcache apcu ldap session' && \
     setup-nginx.sh symfony4 /home/project/pixelfed/public && \
     sed -i 's|listen 80;|listen 8000;|' /etc/nginx/conf.d/default.conf && \


### PR DESCRIPTION
The php modules for pgsql are not enabled by default. This pull request allows the use of postgres as a database. 

Fixes https://github.com/mplx/docker-pixelfed/issues/1#issuecomment-877954700